### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,3 @@
-#Notice
+# Notice
 
 To avoid law issue, only leave a patch x32_php7_patch.diff, Please patch it to *Discuz X3.2 UTF-8 20150609*. Or go to release to download the latest code.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
